### PR TITLE
Introduction and electrostatic cleanup

### DIFF
--- a/appendix/appendix.tex
+++ b/appendix/appendix.tex
@@ -1,6 +1,6 @@
 \begin{appendix}
 
 \section{Bibliography call}
-Need a bibliography call to avoid errors with the SciPost template: \cite{Mills1972}.
+Need a bibliography call to avoid errors: \cite{Mills1972}.
 
 \end{appendix}

--- a/main.tex
+++ b/main.tex
@@ -9,8 +9,9 @@
 
 \begin{document}
 
-
 \input{preamble/preamble.tex}
+
+\input{sections/introduction/introduction.tex}
 
 \input{sections/section-1.tex}
 

--- a/sections/introduction/introduction.tex
+++ b/sections/introduction/introduction.tex
@@ -1,7 +1,7 @@
 \section*{Introduction}
 \addcontentsline{toc}{section}{Introduction}
 
-In this paper, I will demonstrate how to obtain the frequency- and wavevector-resolved density response function of a superlattice,
+In this paper, I will calcaulte the frequency- and wavevector-resolved density response function,
 \begin{equation}
     \label{Fourier chi}
     \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
@@ -9,7 +9,7 @@ In this paper, I will demonstrate how to obtain the frequency- and wavevector-re
     \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
     \,\,\,,
 \end{equation}
-in the long wavelength limit.\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}  By ``superlattice," I mean to consider a system with translation-invariance in the planar directions (those perpendicular to the superlattice dimension),\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are regularly separated by conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as presented in \cite{Cottam1993, Cottam2004}.}  By ``electrostatic,'' I mean to define the system under study in terms of electric potentials and charge densities; i.e., I'll restrict the study of superlattices to the non-relativistic and non-retarded limit.  In terms of the wavevector $q$ and frequency $\omega$ of excitations within this framework, the subsequent electrostatic analysis roughly holds in the regime where $q^2\gg \omega^2/c^2$.
+of a superlattice in the long wavelength limit.\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}  By ``superlattice," I mean to consider a system with translation-invariance along the planar directions (those perpendicular to the superlattice dimension)\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are separated by regularly-spaced conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as presented in \cite{Cottam1993, Cottam2004}.}  I will utilize an electrostatic framework, working in the non-relativistic and non-retarded limit governed by electric potentials and charge densities.  The subseqeuent electrostatic analysis roughly applies in the limit $q^2\gg \omega^2/c^2$, where $q$ and $\omega$ are the wavevector and frequency of excitations within this framework, respectively.
 
 \begin{figure}
     \centering

--- a/sections/introduction/introduction.tex
+++ b/sections/introduction/introduction.tex
@@ -1,0 +1,21 @@
+\section*{Introduction}
+\addcontentsline{toc}{section}{Introduction}
+
+In this paper, I will demonstrate how to obtain the frequency- and wavevector-resolved density response function of a superlattice,
+\begin{equation}
+    \label{Fourier chi}
+    \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
+    :=
+    \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
+    \,\,\,,
+\end{equation}
+in the long wavelength limit.\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}  By ``superlattice," I mean to consider a system with translation-invariance in the planar directions (those perpendicular to the superlattice dimension),\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are regularly separated by conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as presented in \cite{Cottam1993, Cottam2004}.}  By ``electrostatic,'' I mean to define the system under study in terms of electric potentials and charge densities; i.e., I'll restrict the study of superlattices to the non-relativistic and non-retarded limit.  In terms of the wavevector $q$ and frequency $\omega$ of excitations within this framework, the subsequent electrostatic analysis roughly holds in the regime where $q^2\gg \omega^2/c^2$.
+
+\begin{figure}
+    \centering
+    % \includegraphics[width=\columnwidth]{Figures/placeholder.pdf}
+    \caption{
+    {\bf TODO} -- add a figure of the superlattice geometry here.
+    }
+    \label{figure: superlattice geometry}
+\end{figure}

--- a/sections/introduction/introduction.tex
+++ b/sections/introduction/introduction.tex
@@ -3,13 +3,13 @@
 
 The transfer matrix method provides a powerful tool to study systems built from a repeated, macroscopic structure.  In this paper, I will demonstrate how to apply the transfer matrix method to entirely capture the bulk and surface screening response of superlattices.  In particular, we will arrive at an analytical expression for the electronic density response function,
 \begin{equation}
-    \label{Fourier chi}
+    \label{Fourier density response def}
     \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
     :=
     \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
     \,\,\,,
 \end{equation}
-where $q$ is the wavevector and $\omega$ is the frequency of the screening response.  The quantity in \eqref{Fourier chi} warrants study as it governs density-density scattering probes of the superlattice via the fluctuation-dissipation theorem.
+where $q$ is the wavevector and $\omega$ is the frequency of the screening response.  The quantity in \eqref{Fourier density response def} warrants study as it governs density-density scattering probes of the superlattice via the fluctuation-dissipation theorem.
 
 In what follows, ``superlattice" refers to a system with translation-invariance along the planar directions (those perpendicular to the superlattice dimension)\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are separated by regularly-spaced conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as considered in \cite{Cottam1993, Cottam2004}.}  I will utilize an electrostatic framework, working in the non-relativistic and non-retarded limit governed by electric potentials and charge densities.  The subseqeuent electrostatic analysis roughly applies in the limit $q^2\gg \omega^2/c^2$, where $q$ and $\omega$ are the wavevector and frequency of excitations within this framework, respectively.
 

--- a/sections/introduction/introduction.tex
+++ b/sections/introduction/introduction.tex
@@ -1,7 +1,7 @@
 \section*{Introduction}
 \addcontentsline{toc}{section}{Introduction}
 
-In this paper, I will calcaulte the frequency- and wavevector-resolved density response function,
+The transfer matrix method provides a powerful tool to study systems built from a repeated, macroscopic structure.  In this paper, I will demonstrate how to apply the transfer matrix method to entirely capture the bulk and surface screening response of superlattices.  In particular, we will arrive at an analytical expression for the electronic density response function,
 \begin{equation}
     \label{Fourier chi}
     \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
@@ -9,7 +9,9 @@ In this paper, I will calcaulte the frequency- and wavevector-resolved density r
     \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
     \,\,\,,
 \end{equation}
-of a superlattice in the long wavelength limit.\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}  By ``superlattice," I mean to consider a system with translation-invariance along the planar directions (those perpendicular to the superlattice dimension)\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are separated by regularly-spaced conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as presented in \cite{Cottam1993, Cottam2004}.}  I will utilize an electrostatic framework, working in the non-relativistic and non-retarded limit governed by electric potentials and charge densities.  The subseqeuent electrostatic analysis roughly applies in the limit $q^2\gg \omega^2/c^2$, where $q$ and $\omega$ are the wavevector and frequency of excitations within this framework, respectively.
+where $q$ is the wavevector and $\omega$ is the frequency of the screening response.  The quantity in \eqref{Fourier chi} warrants study as it governs density-density scattering probes of the superlattice via the fluctuation-dissipation theorem.
+
+In what follows, ``superlattice" refers to a system with translation-invariance along the planar directions (those perpendicular to the superlattice dimension)\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  In particular, I'll focus on the geometry in Fig. \ref{figure: superlattice geometry}, where dielectric regions are separated by regularly-spaced conducting planes.\footnote{More complicated bi-layer, tri-layer, or n-layer systems are more or less amenable to the same analysis, as considered in \cite{Cottam1993, Cottam2004}.}  I will utilize an electrostatic framework, working in the non-relativistic and non-retarded limit governed by electric potentials and charge densities.  The subseqeuent electrostatic analysis roughly applies in the limit $q^2\gg \omega^2/c^2$, where $q$ and $\omega$ are the wavevector and frequency of excitations within this framework, respectively.
 
 \begin{figure}
     \centering
@@ -19,3 +21,4 @@ of a superlattice in the long wavelength limit.\footnote{Here, the ``long wavele
     }
     \label{figure: superlattice geometry}
 \end{figure}
+

--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -7,7 +7,7 @@ The electrostatic framework considers the screening response of the superlattice
     \rho_{ind}(r,t) = e^2\int d^3 r' dt' \chi(r,r';t-t')\phi_{ext}(r',t')
     \,\,\,.
 \end{equation}
-By Gauss's law, the superlattice contribues a screening field $\phi_{ind}$; in Fourier space,
+Through Gauss's law, the induced charge density sources the screening field $\phi_{ind}$; in Fourier space,
 \begin{equation}
     \label{Fourier phi ind}
     \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
@@ -24,55 +24,54 @@ At the level of linear response, the (total) potential $\phi$ results from the s
 If the superlattice had continuous translation symmetry, the linear response for $\rho_{ind}$ in \eqref{real space chi def} could be expressed in terms of the product of Fourier components for $\chi$ and $\phi_{ext}$.  The superlattice geometry of Fig. \ref{figure: superlattice geometry}, however, has only discrete translation symmetry.  As a result, a potential perturbation with fixed out-of-place wavevector induces a charge density modulation at all reciprocal lattice vectors.  In particular, we have that
 \begin{equation}
     \label{Fourier chi expression}
-    \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dk}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;k+G,k)
+    \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dQ}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;Q+G,Q)
     \,\,\,,
 \end{equation}
-where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector $k$ in \eqref{Fourier chi expression} can be restricted to the first Brillouin zone (denoted as $\bar k$ in what follows),
+where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector $Q$ in \eqref{Fourier chi expression} can be restricted to the first Brillouin zone (nevertheless denoted as $Q$ in what follows),
 \begin{equation}
     \label{Fourier chi G matrix}
-    \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{d\bar k}{2\pi} e^{i\bar k(z-z')}\chi(q_\parallel,\omega;\bar k+G,\bar k+G')
+    \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{dQ}{2\pi} e^{iQ(z-z')}\chi(q_\parallel,\omega;Q+G,Q+G')
     \,\,\,.
 \end{equation}
 The best we can do to simplify the linear response relationship in \eqref{real space chi def} is to obtain a matrix equation in the reciprocal lattice vectors of the superlattice,
 \begin{equation}
     \label{planar linear response}
-     \rho_{ind}(q_\parallel,\omega;\bar k+G) = e^2\sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
-     \phi_{ext}(q_\parallel,\omega;\bar k+G')
+     \rho_{ind}(q_\parallel,\omega;Q+G) = e^2\sum_{G'}\chi(q_\parallel,\omega;Q+G, Q+G')
+     \phi_{ext}(q_\parallel,\omega;Q+G')
      \,\,\,.
 \end{equation}
 
-
-The expression for the total potential $\phi$ \eqref{phi def} can be understood by first expanding the screening field $\phi_{ind}$ \eqref{Fourier phi ind} in terms of the superlattice contributions,
+The superlattice structure contributes to the potential $\phi$ through the screening field $\phi_{ind}$.  Inserting the previous expression for $\rho_{ind}$ \eqref{planar linear response} into the relation for the screening response \eqref{Fourier phi ind},
 \begin{equation}
     \label{planar phi ind}
-     \phi_{ind}(q_\parallel,\omega;\bar k+G) = \frac{e^2}{\e_0\lb q_\parallel^2+\lp\bar k+G\rp^2\rb} \sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
-     \phi_{ext}(q_\parallel,\omega;\bar k+G')
+     \phi_{ind}(q_\parallel,\omega;Q+G) = \frac{e^2}{\e_0\lb q_\parallel^2+\lp Q+G\rp^2\rb} \sum_{G'}\chi(q_\parallel,\omega;Q+G, Q+G')
+     \phi_{ext}(q_\parallel,\omega;Q+G')
      \,\,\,.
 \end{equation}
-Finally, the relationship between the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ can be expressed as
+As a result, the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ are related according to
 \begin{equation}
     \label{planar phi to phi ext relation}
-    \phi(q_\parallel,\omega;\bar k+G) 
+    \phi(q_\parallel,\omega;Q+G) 
     =
     \sum_{G'}
     \lb
     \delta_{G,G'}
     +
-    V(q_\parallel,\bar k+G)
-    \chi(q_\parallel,\omega;\bar k+G, \bar k+G')
+    V(q_\parallel,Q+G)
+    \chi(q_\parallel,\omega;Q+G, Q+G')
     \rb
-    \phi_{ext}(q_\parallel,\omega;\bar k+ G')
+    \phi_{ext}(q_\parallel,\omega;Q+ G')
     \,\,\,,
 \end{equation}
 where I've collected the prefactor of \eqref{planar phi ind} into the Coulomb interaction,
 \begin{equation}
     \label{V def}
-    V(q_\parallel,\bar k+G):=
-    \frac{e^2}{\e_0\lb q_\parallel^2+\lp\bar k+G\rp^2\rb}
+    V(q_\parallel,Q+G):=
+    \frac{e^2}{\e_0\lb q_\parallel^2+\lp Q+G\rp^2\rb}
     \,\,\,.
 \end{equation}
 
-The utility of the electrostatic screening response contained within \eqref{planar phi to phi ext relation} relies on noting that we can control the nature of the probe modeled by $\phi_{ext}$ and that we can decide what part of the total potential $\phi$ to calculate.  If we consider the long wavelength response to a long wavelength perturbation, or $G=G'=0$ in \eqref{planar phi to phi ext relation}, then we can reduce the matrix equation in \eqref{planar phi to phi ext relation} to the {\it scalar} relationship,
+The electrostatic relationship in \eqref{planar phi to phi ext relation} can be greatly simplified in practice.  The experimenter can control the nature of the probe modeled by $\phi_{ext}$.  In particular, we can consider the superlattice response to a long wavelength perturbation, which allows us to ignore all but the $G'=0$ term.  Similarly, we can focus on the long wavelength superlattice response, which separately sets $G=0$.  As a result, the long wavelength response of the superlattice to a long wavelength perturbation is governed by a {\it scalar} equation,
 \begin{equation}
     \label{long wavelength linear response relationship}
     \phi(q_\parallel, Q, \omega) 
@@ -84,5 +83,6 @@ The utility of the electrostatic screening response contained within \eqref{plan
     \chi(q_\parallel, Q, \omega)
     \rb
     \phi_{ext}(q_\parallel, Q, \omega)
-    \,\,\,.
+    \,\,\,,
 \end{equation}
+where $Q$ remains restricted to the first Brillouin zone.  Given a perturbation $\phi_{ext}$, we can use \eqref{long wavelength linear response relationship} to determine the density response function \eqref{Fourier chi} if we can calculate the total potential $\phi$.

--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -7,16 +7,10 @@ The electrostatic framework considers the screening response of the superlattice
     \rho_{ind}(r,t) = e^2\int d^3 r' dt' \chi(r,r';t-t')\phi_{ext}(r',t')
     \,\,\,.
 \end{equation}
-Through Gauss's law, the induced charge density sources the screening field $\phi_{ind}$; in Fourier space,
+Through Gauss's law, the induced charge density sources the screening field $\phi_{ind}$; in Fourier space,\footnote{I'll be working in S.I. units throughout.}
 \begin{equation}
     \label{Fourier phi ind}
     \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
-    \,\,\,.
-\end{equation}
-At the level of linear response, the (total) potential $\phi$ results from the sum
-\begin{equation}
-    \label{phi def}
-    \phi(q,\omega) = \phi_{ind}(q,\omega) + \phi_{ext}(q,\omega)
     \,\,\,.
 \end{equation}
 
@@ -27,7 +21,7 @@ If the superlattice had continuous translation symmetry, the linear response for
     \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dQ}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;Q+G,Q)
     \,\,\,,
 \end{equation}
-where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector $Q$ in \eqref{Fourier chi expression} can be restricted to the first Brillouin zone (nevertheless denoted as $Q$ in what follows),
+where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector---$Q$ in \eqref{Fourier chi expression}---can be restricted to the first Brillouin zone,
 \begin{equation}
     \label{Fourier chi G matrix}
     \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{dQ}{2\pi} e^{iQ(z-z')}\chi(q_\parallel,\omega;Q+G,Q+G')
@@ -41,37 +35,47 @@ The best we can do to simplify the linear response relationship in \eqref{real s
      \,\,\,.
 \end{equation}
 
-The superlattice structure contributes to the potential $\phi$ through the screening field $\phi_{ind}$.  Inserting the previous expression for $\rho_{ind}$ \eqref{planar linear response} into the relation for the screening response \eqref{Fourier phi ind},
+The superlattice structure contributes to the screening response through \eqref{Fourier phi ind},
 \begin{equation}
     \label{planar phi ind}
-     \phi_{ind}(q_\parallel,\omega;Q+G) = \frac{e^2}{\e_0\lb q_\parallel^2+\lp Q+G\rp^2\rb} \sum_{G'}\chi(q_\parallel,\omega;Q+G, Q+G')
+     \phi_{ind}(q_\parallel,\omega;Q+G) = \sum_{G'}V(q_\parallel,Q+G)\chi(q_\parallel,\omega;Q+G, Q+G')
      \phi_{ext}(q_\parallel,\omega;Q+G')
-     \,\,\,.
+     \,\,\,,
 \end{equation}
-As a result, the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ are related according to
-\begin{equation}
-    \label{planar phi to phi ext relation}
-    \phi(q_\parallel,\omega;Q+G) 
-    =
-    \sum_{G'}
-    \lb
-    \delta_{G,G'}
-    +
-    V(q_\parallel,Q+G)
-    \chi(q_\parallel,\omega;Q+G, Q+G')
-    \rb
-    \phi_{ext}(q_\parallel,\omega;Q+ G')
-    \,\,\,,
-\end{equation}
-where I've collected the prefactor of \eqref{planar phi ind} into the Coulomb interaction,
+where I've defined the Coulomb interaction,
 \begin{equation}
     \label{V def}
     V(q_\parallel,Q+G):=
     \frac{e^2}{\e_0\lb q_\parallel^2+\lp Q+G\rp^2\rb}
     \,\,\,.
 \end{equation}
+The {\it total} potential $\phi$ is then made up of three components,
+\begin{equation}
+    \label{total potential def}
+    \phi = \phi_0 + \phi_{ind} + \phi_{ext},
+\end{equation}
+where $\phi_0$ describes the micro-structure of the unperturbed superlattice potential.\footnote{The macroscopic constituents in Fig. \ref{figure: superlattice geometry} are presumed charge-neutral on the whole, but nevertheless contain ionic and electronic charge densities that vary on microscopic length scales.}  As a result, the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ are related according to
+\begin{eqnarray}
+    \label{planar phi to phi ext relation}
+    \nonumber 
+    \phi(q_\parallel,\omega;Q+G) 
+    &=&
+    \phi_0(q_\parallel, \omega; Q+G) 
+    \\ \nonumber &\,& +
+    \Bigg(\sum_{G'}
+    \lb
+    \delta_{G,G'}
+    +
+    V(q_\parallel,Q+G)
+    \chi(q_\parallel,\omega;Q+G, Q+G')
+    \rb
+    \\ &\,&
+    \times
+    \phi_{ext}(q_\parallel,\omega;Q+ G')\Bigg)
+    \,\,\,.
+\end{eqnarray}
 
-The electrostatic relationship in \eqref{planar phi to phi ext relation} can be greatly simplified in practice.  The experimenter can control the nature of the probe modeled by $\phi_{ext}$.  In particular, we can consider the superlattice response to a long wavelength perturbation, which allows us to ignore all but the $G'=0$ term.  Similarly, we can focus on the long wavelength superlattice response, which separately sets $G=0$.  As a result, the long wavelength response of the superlattice to a long wavelength perturbation is governed by a {\it scalar} equation,
+The electrostatic relationship in \eqref{planar phi to phi ext relation} can be greatly simplified if we restrict our study to the long wavelength limit.  We can neglect the micro-structure $\phi_0$ by two separate arguments.  If we strict ourselves to truly dynamic $\omega>0$ response, then $\phi_0$ should not contribute as it describes the static superlattice.  Additionally, $\phi_0$ should not contribute in the long wavelength $G=0$ limit due to charge neutrality.\footnote{This is more subtle, as I need to argue that we don't have any interesting commensurate structures arising from the inter-play of superlattice and microscopic lattice scales.  A truly microscopic analysis might find interesting long wavelength contributions due to these effects.}  Either way, we can safely neglect $\phi_0$ in the subsequent electrostatic analysis by focusing on the $G=0$ response.  On the right-hand side of \eqref{planar phi to phi ext relation}, the experimenter can control the nature of the probe modeled by $\phi_{ext}$.  In particular, we can consider the superlattice response to a long wavelength perturbation, where $G'=0$.  As a result, the long wavelength response of the superlattice to a long wavelength perturbation is governed by a {\it scalar} equation,
 \begin{equation}
     \label{long wavelength linear response relationship}
     \phi(q_\parallel, Q, \omega) 
@@ -85,4 +89,4 @@ The electrostatic relationship in \eqref{planar phi to phi ext relation} can be 
     \phi_{ext}(q_\parallel, Q, \omega)
     \,\,\,,
 \end{equation}
-where $Q$ remains restricted to the first Brillouin zone.  Given a perturbation $\phi_{ext}$, we can use \eqref{long wavelength linear response relationship} to determine the density response function \eqref{Fourier chi} if we can calculate the total potential $\phi$.
+where $Q$ remains restricted to the first Brillouin zone.  If we can solve for $\phi$ in the presence of a generic perturbation $\phi_{ext}$, then \eqref{long wavelength linear response relationship} allows us to determine the density response function $\chi$ \eqref{Fourier chi}.

--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -9,7 +9,7 @@ The electrostatic framework considers the screening response of the superlattice
 \end{equation}
 Through Gauss's law, the induced charge density sources the screening field $\phi_{ind}$; in Fourier space,\footnote{I'll be working in S.I. units throughout.}
 \begin{equation}
-    \label{Fourier phi ind}
+    \label{Fourier induced Gauss law}
     \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
     \,\,\,.
 \end{equation}
@@ -17,46 +17,41 @@ Through Gauss's law, the induced charge density sources the screening field $\ph
 
 If the superlattice had continuous translation symmetry, the linear response for $\rho_{ind}$ in \eqref{real space chi def} could be expressed in terms of the product of Fourier components for $\chi$ and $\phi_{ext}$.  The superlattice geometry of Fig. \ref{figure: superlattice geometry}, however, has only discrete translation symmetry.  As a result, a potential perturbation with fixed out-of-place wavevector induces a charge density modulation at all reciprocal lattice vectors.  In particular, we have that
 \begin{equation}
-    \label{Fourier chi expression}
+    \label{superlattice density response structure}
     \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dQ}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;Q+G,Q)
     \,\,\,,
 \end{equation}
-where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector---$Q$ in \eqref{Fourier chi expression}---can be restricted to the first Brillouin zone,
+where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector---$Q$ in \eqref{superlattice density response structure}---can be restricted to the first Brillouin zone,
 \begin{equation}
-    \label{Fourier chi G matrix}
     \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{dQ}{2\pi} e^{iQ(z-z')}\chi(q_\parallel,\omega;Q+G,Q+G')
     \,\,\,.
 \end{equation}
 The best we can do to simplify the linear response relationship in \eqref{real space chi def} is to obtain a matrix equation in the reciprocal lattice vectors of the superlattice,
 \begin{equation}
-    \label{planar linear response}
      \rho_{ind}(q_\parallel,\omega;Q+G) = e^2\sum_{G'}\chi(q_\parallel,\omega;Q+G, Q+G')
      \phi_{ext}(q_\parallel,\omega;Q+G')
      \,\,\,.
 \end{equation}
 
-The superlattice structure contributes to the screening response through \eqref{Fourier phi ind},
+The superlattice structure contributes to the screening response through \eqref{Fourier induced Gauss law},
 \begin{equation}
-    \label{planar phi ind}
      \phi_{ind}(q_\parallel,\omega;Q+G) = \sum_{G'}V(q_\parallel,Q+G)\chi(q_\parallel,\omega;Q+G, Q+G')
      \phi_{ext}(q_\parallel,\omega;Q+G')
      \,\,\,,
 \end{equation}
 where I've defined the Coulomb interaction,
 \begin{equation}
-    \label{V def}
     V(q_\parallel,Q+G):=
     \frac{e^2}{\e_0\lb q_\parallel^2+\lp Q+G\rp^2\rb}
     \,\,\,.
 \end{equation}
 The {\it total} potential $\phi$ is then made up of three components,
 \begin{equation}
-    \label{total potential def}
     \phi = \phi_0 + \phi_{ind} + \phi_{ext},
 \end{equation}
 where $\phi_0$ describes the micro-structure of the unperturbed superlattice potential.\footnote{The macroscopic constituents in Fig. \ref{figure: superlattice geometry} are presumed charge-neutral on the whole, but nevertheless contain ionic and electronic charge densities that vary on microscopic length scales.}  As a result, the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ are related according to
 \begin{eqnarray}
-    \label{planar phi to phi ext relation}
+    \label{microscopic total potential expression}
     \nonumber 
     \phi(q_\parallel,\omega;Q+G) 
     &=&
@@ -75,9 +70,9 @@ where $\phi_0$ describes the micro-structure of the unperturbed superlattice pot
     \,\,\,.
 \end{eqnarray}
 
-The electrostatic relationship in \eqref{planar phi to phi ext relation} can be greatly simplified if we restrict our study to the long wavelength limit.  We can neglect the micro-structure $\phi_0$ by two separate arguments.  If we strict ourselves to truly dynamic $\omega>0$ response, then $\phi_0$ should not contribute as it describes the static superlattice.  Additionally, $\phi_0$ should not contribute in the long wavelength $G=0$ limit due to charge neutrality.\footnote{This is more subtle, as I need to argue that we don't have any interesting commensurate structures arising from the inter-play of superlattice and microscopic lattice scales.  A truly microscopic analysis might find interesting long wavelength contributions due to these effects.}  Either way, we can safely neglect $\phi_0$ in the subsequent electrostatic analysis by focusing on the $G=0$ response.  On the right-hand side of \eqref{planar phi to phi ext relation}, the experimenter can control the nature of the probe modeled by $\phi_{ext}$.  In particular, we can consider the superlattice response to a long wavelength perturbation, where $G'=0$.  As a result, the long wavelength response of the superlattice to a long wavelength perturbation is governed by a {\it scalar} equation,
+The electrostatic relationship in \eqref{microscopic total potential expression} can be greatly simplified if we restrict our study to the long wavelength limit.  We can neglect the micro-structure $\phi_0$ by two separate arguments.  If we strict ourselves to truly dynamic $\omega>0$ response, then $\phi_0$ should not contribute as it describes the static superlattice.  Additionally, $\phi_0$ should not contribute in the long wavelength $G=0$ limit due to charge neutrality.\footnote{This is more subtle, as I need to argue that we don't have any interesting commensurate structures arising from the inter-play of superlattice and microscopic lattice scales.  A truly microscopic analysis might find interesting long wavelength contributions due to these effects.}  Either way, we can safely neglect $\phi_0$ in the subsequent electrostatic analysis by focusing on the $G=0$ response.  On the right-hand side of \eqref{microscopic total potential expression}, the experimenter can control the nature of the probe modeled by $\phi_{ext}$.  In particular, we can consider the superlattice response to a long wavelength perturbation, where $G'=0$.  As a result, the long wavelength response of the superlattice to a long wavelength perturbation is governed by a {\it scalar} equation,
 \begin{equation}
-    \label{long wavelength linear response relationship}
+    \label{long wavelength total potential}
     \phi(q_\parallel, Q, \omega) 
     =
     \lb
@@ -89,4 +84,4 @@ The electrostatic relationship in \eqref{planar phi to phi ext relation} can be 
     \phi_{ext}(q_\parallel, Q, \omega)
     \,\,\,,
 \end{equation}
-where $Q$ remains restricted to the first Brillouin zone.  If we can solve for $\phi$ in the presence of a generic perturbation $\phi_{ext}$, then \eqref{long wavelength linear response relationship} allows us to determine the density response function $\chi$ \eqref{Fourier chi}.
+where $Q$ remains restricted to the first Brillouin zone.  If we can solve for $\phi$ in the presence of a generic perturbation $\phi_{ext}$, then \eqref{long wavelength total potential} allows us to determine the density response function $\chi$ \eqref{Fourier density response def}.

--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -1,28 +1,27 @@
 \section{The electrostatic framework}
 \label{section: electrostatic framework}
 
-The electrostatic framework provides a direct means of calculating the electronic density response of a superlattice through an electrostatic screening analysis.  In particular, I will demonstrate how to obtain the frequency- and wavevector-resolved density response function in the long wavelength limit,\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}
-\begin{equation}
-    \label{Fourier chi}
-    \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
-    :=
-    \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
-    \,\,\,.
-\end{equation}
-By superlattice, I mean to consider a system with translation-invariance in the planar directions (those perpendicular to the superlattice dimension),\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  By ``electrostatic,'' I mean to define the system under study in terms of electric potentials and charge densities, which restricts the calculation to the non-relativistic and non-retarded limit.  In terms of the wavevector $q$ and frequency $\omega$ of excitations within this framework, an electrostatic analysis roughly holds in the regime where $q^2\gg \omega^2/c^2$.
-
-
-The electrostatic framework considers the response of an electronic, bound charge density to an externally-sourced perturbing potential, $\phi_{ext}$.  The perturbing field induces a screening charge density $\rho_{ind}$, which is governed by 
-the electronic density response function $\chi$,\footnote{I.e., we are ignoring ionic contributions to the electrostatic screening response.  This neglected response would nevertheless contribute to charge density probes like EELS.}
+The electrostatic framework considers the screening response of the superlattice perturbed by an externally-sourced potential, $\phi_{ext}$.  The perturbing field induces a screening charge density $\rho_{ind}$, which is governed by the electronic density response function $\chi$,\footnote{I.e., we are ignoring ionic contributions to the electrostatic screening response.  This neglected response would nevertheless contribute to charge density probes like EELS.}
 \begin{equation}
     \label{real space chi def}
     \rho_{ind}(r,t) = e^2\int d^3 r' dt' \chi(r,r';t-t')\phi_{ext}(r',t')
     \,\,\,.
 \end{equation}
+By Gauss's law, the superlattice contribues a screening field $\phi_{ind}$; in Fourier space,
+\begin{equation}
+    \label{Fourier phi ind}
+    \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
+    \,\,\,.
+\end{equation}
+At the level of linear response, the (total) potential $\phi$ results from the sum
+\begin{equation}
+    \label{phi def}
+    \phi(q,\omega) = \phi_{ind}(q,\omega) + \phi_{ext}(q,\omega)
+    \,\,\,.
+\end{equation}
 
 
-
-As such, out-of-plane wavevectors are only conserved up to reciprocal lattice vectors,
+If the superlattice had continuous translation symmetry, the linear response for $\rho_{ind}$ in \eqref{real space chi def} could be expressed in terms of the product of Fourier components for $\chi$ and $\phi_{ext}$.  The superlattice geometry of Fig. \ref{figure: superlattice geometry}, however, has only discrete translation symmetry.  As a result, a potential perturbation with fixed out-of-place wavevector induces a charge density modulation at all reciprocal lattice vectors.  In particular, we have that
 \begin{equation}
     \label{Fourier chi expression}
     \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dk}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;k+G,k)
@@ -34,12 +33,7 @@ where $q_\parallel$ is the planar component of the Fourier wavevector and the su
     \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{d\bar k}{2\pi} e^{i\bar k(z-z')}\chi(q_\parallel,\omega;\bar k+G,\bar k+G')
     \,\,\,.
 \end{equation}
-
-
-
-
-
-The linear response relationship in \eqref{real space chi def} can be expressed in terms of the discrete superlattice translation symmetry in \eqref{Fourier chi G matrix} as a matrix equation in reciprocal lattice vectors,
+The best we can do to simplify the linear response relationship in \eqref{real space chi def} is to obtain a matrix equation in the reciprocal lattice vectors of the superlattice,
 \begin{equation}
     \label{planar linear response}
      \rho_{ind}(q_\parallel,\omega;\bar k+G) = e^2\sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
@@ -48,32 +42,14 @@ The linear response relationship in \eqref{real space chi def} can be expressed 
 \end{equation}
 
 
-The screening field $\phi_{ind}$ is sourced by an induced charge density $\rho_{ind}$ through Gauss's law; in Fourier space,
-\begin{equation}
-    \label{Fourier phi ind}
-    \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
-    \,\,\,.
-\end{equation}
-
-
-An analogous matrix equation results for the screening field,
+The expression for the total potential $\phi$ \eqref{phi def} can be understood by first expanding the screening field $\phi_{ind}$ \eqref{Fourier phi ind} in terms of the superlattice contributions,
 \begin{equation}
     \label{planar phi ind}
      \phi_{ind}(q_\parallel,\omega;\bar k+G) = \frac{e^2}{\e_0\lb q_\parallel^2+\lp\bar k+G\rp^2\rb} \sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
      \phi_{ext}(q_\parallel,\omega;\bar k+G')
      \,\,\,.
 \end{equation}
-
-
-At the level of linear response, the (total) potential $\phi$ results from the sum
-\begin{equation}
-    \label{phi def}
-    \phi(q,\omega) = \phi_{ind}(q,\omega) + \phi_{ext}(q,\omega)
-    \,\,\,.
-\end{equation}
-
-
-The expression for the (total) potential $\phi$ can similarly be written in terms of $\phi_{ext}$ through its definition in \eqref{phi def} as
+Finally, the relationship between the total potential $\phi$, the electronic density response function $\chi$, and the perturbing potential $\phi_{ext}$ can be expressed as
 \begin{equation}
     \label{planar phi to phi ext relation}
     \phi(q_\parallel,\omega;\bar k+G) 
@@ -88,10 +64,25 @@ The expression for the (total) potential $\phi$ can similarly be written in term
     \phi_{ext}(q_\parallel,\omega;\bar k+ G')
     \,\,\,,
 \end{equation}
-where we've collected the prefactor of \eqref{planar phi ind} into the Coulomb interaction,
+where I've collected the prefactor of \eqref{planar phi ind} into the Coulomb interaction,
 \begin{equation}
     \label{V def}
     V(q_\parallel,\bar k+G):=
     \frac{e^2}{\e_0\lb q_\parallel^2+\lp\bar k+G\rp^2\rb}
+    \,\,\,.
+\end{equation}
+
+The utility of the electrostatic screening response contained within \eqref{planar phi to phi ext relation} relies on noting that we can control the nature of the probe modeled by $\phi_{ext}$ and that we can decide what part of the total potential $\phi$ to calculate.  If we consider the long wavelength response to a long wavelength perturbation, or $G=G'=0$ in \eqref{planar phi to phi ext relation}, then we can reduce the matrix equation in \eqref{planar phi to phi ext relation} to the {\it scalar} relationship,
+\begin{equation}
+    \label{long wavelength linear response relationship}
+    \phi(q_\parallel, Q, \omega) 
+    =
+    \lb
+    1
+    +
+    V(q_\parallel, Q)
+    \chi(q_\parallel, Q, \omega)
+    \rb
+    \phi_{ext}(q_\parallel, Q, \omega)
     \,\,\,.
 \end{equation}

--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -1,27 +1,7 @@
-\section{The electromagnetic framework}
-\label{section: electromagnetic framework}
+\section{The electrostatic framework}
+\label{section: electrostatic framework}
 
-The benefit of the electromagnetic framework is that one can infer the electronic response of the material from a purely electromagnetic calculation of the electric potential in a material perturbed by an external charge density.  By working with a theory of potentials and charge densities, we are implicitly restricting our study to the non-relativistic, non-retarded limit; in terms of the wavevector $q$ and frequency $\omega$ of excitations under consideration, this translates to the regime $q^2\gg \omega^2/c^2$.  The perturbing field $\phi_{ext}$ in an electromagnetic analysis is chosen for convenience, since its role is to generate the desired material response.  Given a particular $\phi_{ext}$, we work backwards by characterizing the many-electron screening of the material through the action of the electronic density response function $\chi$,\footnote{I.e., we are ignoring ionic contributions to the electromagnetic screening response.  This neglected response would nevertheless contribute to charge density probes like EELS.}
-\begin{equation}
-    \label{real space chi def}
-    \rho_{ind}(r,t) = e^2\int d^3 r' dt' \chi(r,r';t-t')\phi_{ext}(r',t')
-    \,\,\,,
-\end{equation}
-where $\rho_{ind}$ is the electronic charge density induced by the externally-sourced electric potential $\phi_{ext}$.  The induced charge density \eqref{real space chi def} sources the material screening field $\phi_{ind}$ through Gauss's law, which has the Fourier components
-\begin{equation}
-    \label{Fourier phi ind}
-    \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
-    \,\,\,.
-\end{equation}
-The total potential $\phi$, at the level of linear response, is then given by the sum
-\begin{equation}
-    \label{phi def}
-    \phi(q,\omega) = \phi_{ind}(q,\omega) + \phi_{ext}(q,\omega)
-    \,\,\,,
-\end{equation}
-which contains the material response through $\phi_{ind}$ \eqref{Fourier phi ind}.  
-
-When using an electromagnetic (or ``dielectric") analysis to extract the electron energy loss function, we ultimately desire the frequency- and wavevector-resolved density response function,
+The electrostatic framework provides a direct means of calculating the electronic density response of a superlattice through an electrostatic screening analysis.  In particular, I will demonstrate how to obtain the frequency- and wavevector-resolved density response function in the long wavelength limit,\footnote{Here, the ``long wavelength limit'' refers to wavevectors along the superlattice direction that lie within the first Brillouin zone.}
 \begin{equation}
     \label{Fourier chi}
     \chi(q,\omega):=\chi(q,q';\omega)_{q=q'}
@@ -29,34 +9,71 @@ When using an electromagnetic (or ``dielectric") analysis to extract the electro
     \lb\frac{1}{\vol}\int d^3 r d^3 r' e^{iq\cdot r} e^{-i q'\cdot r'}\chi(r,r';\omega)\rb_{q=q'}
     \,\,\,.
 \end{equation}
-The difficulty of modeling the response of a material is often due to its lack of homogeneity, which results in the need for the double Fourier transform in \eqref{Fourier chi}.  In systems with translation-invariance, \eqref{Fourier chi} reduces to the expected Fourier transform.  When applied to a superlattice, we presume translation-invariance in the planar directions (those perpendicular to the superlattice dimension), but have only discrete translation symmetry in the layering direction.  As such, out-of-plane wavevectors are only conserved up to reciprocal lattice vectors,
+By superlattice, I mean to consider a system with translation-invariance in the planar directions (those perpendicular to the superlattice dimension),\footnote{This assumption can be relaxed to the discrete translation symmetry of a crystalline solid, so long as the ``long wavelength limit'' is appropriately redefined.} and discrete translation symmetry in the layering direction.  By ``electrostatic,'' I mean to define the system under study in terms of electric potentials and charge densities, which restricts the calculation to the non-relativistic and non-retarded limit.  In terms of the wavevector $q$ and frequency $\omega$ of excitations within this framework, an electrostatic analysis roughly holds in the regime where $q^2\gg \omega^2/c^2$.
+
+
+The electrostatic framework considers the response of an electronic, bound charge density to an externally-sourced perturbing potential, $\phi_{ext}$.  The perturbing field induces a screening charge density $\rho_{ind}$, which is governed by 
+the electronic density response function $\chi$,\footnote{I.e., we are ignoring ionic contributions to the electrostatic screening response.  This neglected response would nevertheless contribute to charge density probes like EELS.}
+\begin{equation}
+    \label{real space chi def}
+    \rho_{ind}(r,t) = e^2\int d^3 r' dt' \chi(r,r';t-t')\phi_{ext}(r',t')
+    \,\,\,.
+\end{equation}
+
+
+
+As such, out-of-plane wavevectors are only conserved up to reciprocal lattice vectors,
 \begin{equation}
     \label{Fourier chi expression}
     \chi(q_\parallel,\omega;z,z') = \sum_G e^{iG z} \int \frac{dk}{2\pi} e^{ik(z-z')}\chi(q_\parallel,\omega;k+G,k)
     \,\,\,,
 \end{equation}
-where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, we enumerate the continuous out-of-plane wavevector $k$ in \eqref{Fourier chi expression} through its restriction to the first Brillouin zone --- denoted by $\bar k$ --- and a remainder, which is a reciprocal lattice vector.  Now, the Fourier transform of $\chi$ is a matrix in the out-of-plane reciprocal vectors and \eqref{Fourier chi expression} becomes
+where $q_\parallel$ is the planar component of the Fourier wavevector and the sum is over all out-of-plane reciprocal vectors.  As is standard, the continuous out-of-plane wavevector $k$ in \eqref{Fourier chi expression} can be restricted to the first Brillouin zone (denoted as $\bar k$ in what follows),
 \begin{equation}
     \label{Fourier chi G matrix}
     \chi(q_\parallel,\omega;z,z') = \sum_{G,G'} e^{iG z} e^{-i G' z'} \int_\text{BZ} \frac{d\bar k}{2\pi} e^{i\bar k(z-z')}\chi(q_\parallel,\omega;\bar k+G,\bar k+G')
     \,\,\,.
 \end{equation}
 
-The structure of \eqref{Fourier chi G matrix} transforms the real-space linear response relationship of \eqref{real space chi def} into the matrix equation
+
+
+
+
+The linear response relationship in \eqref{real space chi def} can be expressed in terms of the discrete superlattice translation symmetry in \eqref{Fourier chi G matrix} as a matrix equation in reciprocal lattice vectors,
 \begin{equation}
     \label{planar linear response}
      \rho_{ind}(q_\parallel,\omega;\bar k+G) = e^2\sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
      \phi_{ext}(q_\parallel,\omega;\bar k+G')
-     \,\,\,,
+     \,\,\,.
 \end{equation}
-which results an analogous matrix equation for the screening field,
+
+
+The screening field $\phi_{ind}$ is sourced by an induced charge density $\rho_{ind}$ through Gauss's law; in Fourier space,
+\begin{equation}
+    \label{Fourier phi ind}
+    \phi_{ind}(q,\omega) = \frac{\rho_{ind}(q,\omega)}{\e_0 q^2}
+    \,\,\,.
+\end{equation}
+
+
+An analogous matrix equation results for the screening field,
 \begin{equation}
     \label{planar phi ind}
      \phi_{ind}(q_\parallel,\omega;\bar k+G) = \frac{e^2}{\e_0\lb q_\parallel^2+\lp\bar k+G\rp^2\rb} \sum_{G'}\chi(q_\parallel,\omega;\bar k+G, \bar k+G')
      \phi_{ext}(q_\parallel,\omega;\bar k+G')
      \,\,\,.
 \end{equation}
-The reciprocal components of the (total) potential $\phi$ can now be written in terms of $\phi_{ext}$ through the linear response relation as
+
+
+At the level of linear response, the (total) potential $\phi$ results from the sum
+\begin{equation}
+    \label{phi def}
+    \phi(q,\omega) = \phi_{ind}(q,\omega) + \phi_{ext}(q,\omega)
+    \,\,\,.
+\end{equation}
+
+
+The expression for the (total) potential $\phi$ can similarly be written in terms of $\phi_{ext}$ through its definition in \eqref{phi def} as
 \begin{equation}
     \label{planar phi to phi ext relation}
     \phi(q_\parallel,\omega;\bar k+G) 

--- a/sections/section-2/section-2-2.tex
+++ b/sections/section-2/section-2-2.tex
@@ -187,4 +187,4 @@ Upon inverting the eigenvalue inequalities in \eqref{eigenvalue relation} and re
 \end{equation}
 Through the eigenvector decompositions for $\ket{\bar\phi_n}$ \eqref{eigen decomp phi}, $\ket r$ \eqref{eigen decomp r}, and $\ket d$ \eqref{eigen decomp d}, the boundedness constraints in \eqref{forward BC} and \eqref{backward BC} totally determine the $\ket{\bar\phi_n}$ and subsequently the potential within the entire superlattice.
 
-\note{Next}: Fourier transform this solution along the $z$-direction so that $\chi$ can be extracted from \eqref{planar phi to phi ext relation}.  In particular, the long wavelength response to a long wavelength perturbation is a scalar relationship with $G,G'=0$ fixed.
+\note{Next}: Fourier transform this solution along the $z$-direction so that $\chi$ can be extracted from \eqref{microscopic total potential expression}.  In particular, the long wavelength response to a long wavelength perturbation is a scalar relationship with $G,G'=0$ fixed.


### PR DESCRIPTION
These edits largely focused on adding some introduction (not fully fleshed out) and re-organizing the discussion through the electrostatic section.  

## Changed
- Removed explicit SciPost templating, moving toward a custom TeX structure only loosely based on their margins/colors
- Updated labeling, favoring readable phrases and removing unused labels to allow for simpler names
- Re-organized logic on the long wavelength limit, and stated the goal of calculating the density response function
- Broadly refactored the electrostatic section to make the motivations and reasoning more clear